### PR TITLE
Fix background blit

### DIFF
--- a/main.py
+++ b/main.py
@@ -165,9 +165,9 @@ def main():
         
 
         #blits all the objects on to the display every frame
-        display.blit(background.image, puck.rect, puck.rect) 
-        display.blit(background.image, player1.rect, player1.rect)
-        display.blit(background.image, player2.rect, player2.rect)
+        display.blit(background, puck.rect, puck.rect)
+        display.blit(background, player1.rect, player1.rect)
+        display.blit(background, player2.rect, player2.rect)
         display.blit(player1Text, (550, 175))
         display.blit(player2Text, (220, 175))
         display.blit(timeText, (340, 180))


### PR DESCRIPTION
## Summary
- prevent `AttributeError` when clearing sprite rectangles

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `SDL_VIDEODRIVER=dummy python main.py` *(fails: ModuleNotFoundError: No module named 'pygame')*

------
https://chatgpt.com/codex/tasks/task_e_687115e6a3508331a8b548680a59af04