### PR TITLE
Fix puck initialization and image loader

### DIFF
--- a/classes.py
+++ b/classes.py
@@ -17,9 +17,8 @@ def load_img(name):
     '''
     try:
         image = pygame.image.load(name)
-        
-    except py.error:
-        raise SystemExit(str(geterror()))
+    except pygame.error as e:
+        raise SystemExit(str(e))
     return image, image.get_rect()
 
 class Background(pygame.sprite.Sprite):
@@ -82,7 +81,7 @@ class Puck(pygame.sprite.Sprite):
     def __init__(self, angle, speed):
         #variable instantiation
         pygame.sprite.Sprite.__init__(self)
-        self.image, self.rect = load_img('puck.png')
+        self.image, self.rect = load_img('models/puck.png')
         screen = pygame.display.get_surface()
         self.area = screen.get_rect()
         self.angle = angle

--- a/main.py
+++ b/main.py
@@ -17,15 +17,8 @@ def main():
     player2Score = Scores('digital-7.ttf', 70, 0) 
 
     
-    
-    puck = pygame.image.load('models/puck.png')
-    puck_offset = (puck.get_height()/2, puck.get_width()/2)
-    red_paddle_img = pygame.image.load('models/red_paddle.png')
-    red_paddle = pygame.transform.scale(red_paddle_img, (150, 150))
-    red_paddle_offset = (red_paddle.get_height()/2, red_paddle.get_width()/2)
-    blue_paddle_img = pygame.image.load('models/blue_paddle.png')
-    blue_paddle = pygame.transform.scale(blue_paddle_img, (150, 150))
-    blue_paddle_offset = (blue_paddle.get_height()/2, blue_paddle.get_width()/2)
+    puck = Puck(random.uniform(0, 2 * math.pi), 0)
+    puck_group = pygame.sprite.RenderPlain(puck)
 
     player1_obj = Player1()
     player1 = pygame.sprite.RenderPlain(player1_obj)
@@ -126,8 +119,8 @@ def main():
             mainM = True
 
         #updating the scores 
-        player1Text = player1Score.render(str(puck.playerScore), False, (0,0,0))
-        #player2Text = player2Score.render(str(puck.player2Score), False, (0,0,0))
+        player1Text = player1Score.render(str(puck.player1Score), False, (0,0,0))
+        player2Text = player2Score.render(str(puck.player2Score), False, (0,0,0))
 
         #checking the updating the clock 
         timeElapsed = clock.tick(60)
@@ -143,14 +136,14 @@ def main():
                 player1.mouseMove()
             
         #checks for the collision between puck and player sprite, handles its collision
-        if pygame.sprite.groupcollide(puck, player1, False, False, pygame.sprite.collide_circle):
+        if pygame.sprite.groupcollide(puck_group, player1, False, False, pygame.sprite.collide_circle):
 
             (dx, dy) = pygame.mouse.get_rel()
             
             puck.angle = math.atan2(dy, dx)
             puck.speed = 30
 
-        if pygame.sprite.groupcollide(puck, player2, False, False, pygame.sprite.collide_circle):
+        if pygame.sprite.groupcollide(puck_group, player2, False, False, pygame.sprite.collide_circle):
 
             (dx, dy) = pygame.mouse.get_rel()
             
@@ -159,15 +152,15 @@ def main():
     
         #places the puck back in the 
         if puck.goal:
-            puck.goal = False 
+            puck.goal = False
             puck.rect.center = puck.area.center
 
         
 
         #blits all the objects on to the display every frame
-        display.blit(background.image, puck.rect, puck.rect) 
-        display.blit(background.image, player1.rect, player1.rect)
-        display.blit(background.image, player2.rect, player2.rect)
+        display.blit(background, puck.rect, puck.rect)
+        display.blit(background, player1_obj.rect, player1_obj.rect)
+        display.blit(background, player2_obj.rect, player2_obj.rect)
         display.blit(player1Text, (550, 175))
         display.blit(player2Text, (220, 175))
         display.blit(timeText, (340, 180))
@@ -175,13 +168,13 @@ def main():
         
         #updates the sprites 
         player1.update()
-        player2.update() 
-        puck.update()
+        player2.update()
+        puck_group.update()
     
         
         player1.draw(display)
         player2.draw(display)
-        puck.draw(display)
+        puck_group.draw(display)
         
     
         pygame.display.flip()


### PR DESCRIPTION
## Summary
- handle pygame errors in `load_img`
- load puck image from models directory
- initialize puck as a sprite and maintain a group
- fix score rendering and sprite blitting logic

## Testing
- `python3 -m py_compile classes.py main.py`
- `SDL_VIDEODRIVER=dummy python3 main.py` *(fails: KeyboardInterrupt after manual quit)*

------
https://chatgpt.com/codex/tasks/task_e_68711538c34c83319f89d578d2998301